### PR TITLE
Update to Tide 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,7 +1249,7 @@ dependencies = [
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_qs 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tide 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tide 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1482,10 +1491,11 @@ dependencies = [
 
 [[package]]
 name = "tide"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-service 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1814,6 +1824,7 @@ dependencies = [
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
+"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
@@ -1954,7 +1965,7 @@ dependencies = [
 "checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
 "checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum tide 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13c99b1991db81e611a2614cd1b07fec89ae33c5f755e1f8eb70826fb5af0eea"
+"checksum tide 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e619c99048ae107912703d0efeec4ff4fbff704f064e51d3eee614b28ea7b739"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/src/web/Cargo.toml
+++ b/src/web/Cargo.toml
@@ -9,7 +9,7 @@ name = "realworld_web"
 path = "src/lib.rs"
 
 [dependencies]
-tide = { version = "0.5" }
+tide = { version = "0.6" }
 serde = { version= "1", features = ["derive"] }
 serde_urlencoded = "0.5.4"
 chrono = { version = "0.4.6", features = ["serde"] }

--- a/src/web/src/app.rs
+++ b/src/web/src/app.rs
@@ -1,6 +1,8 @@
 use crate::Context;
 use domain::repositories::Repository;
 use tide::{IntoResponse, Response, Server};
+use tide::middleware::{Cors, Origin};
+use http::HeaderValue;
 
 pub fn result_to_response<T: IntoResponse, E: IntoResponse>(r: Result<T, E>) -> Response {
     match r {
@@ -64,7 +66,12 @@ pub fn add_routes<R: Repository + Send + Sync>(mut api: Server<Context<R>>) -> S
 }
 
 pub fn add_middleware<State: 'static + Sync + Send>(mut app: Server<State>) -> Server<State> {
+    let rules = Cors::new()
+        .allow_methods(HeaderValue::from_static("GET, POST, OPTIONS"))
+        .allow_origin(Origin::from("*"))
+        .allow_credentials(false);
     app.middleware(tide::middleware::RequestLogger::new());
+    app.middleware(rules);
     app.middleware(crate::middleware::JwtMiddleware::new());
     app
 }

--- a/src/web/src/app.rs
+++ b/src/web/src/app.rs
@@ -1,8 +1,8 @@
 use crate::Context;
 use domain::repositories::Repository;
-use tide::{IntoResponse, Response, Server};
-use tide::middleware::{Cors, Origin};
 use http::HeaderValue;
+use tide::middleware::{Cors, Origin};
+use tide::{IntoResponse, Response, Server};
 
 pub fn result_to_response<T: IntoResponse, E: IntoResponse>(r: Result<T, E>) -> Response {
     match r {

--- a/src/web/src/app.rs
+++ b/src/web/src/app.rs
@@ -26,49 +26,41 @@ pub fn get_app<R: Repository + Send + Sync>(repository: R) -> Server<Context<R>>
     app
 }
 
-pub fn add_routes<R: Repository + Send + Sync>(mut app: Server<Context<R>>) -> Server<Context<R>> {
-    app.at("/api").nest(|api| {
-        api.at("/user")
-            .get(|req| async move { result_to_response(crate::users::get_current_user(req).await) })
-            .put(|req| async move { result_to_response(crate::users::update_user(req).await) });
-        api.at("/users")
-            .post(|req| async move { result_to_response(crate::users::register(req).await) });
-        api.at("/users/login")
-            .post(|req| async move { result_to_response(crate::users::login(req).await) });
-        api.at("/profiles/:username")
-            .get(|req| async move { result_to_response(crate::profiles::get_profile(req).await) });
-        api.at("/profiles/:username/follow")
-            .post(|req| async move { result_to_response(crate::profiles::follow(req).await) })
-            .delete(|req| async move { result_to_response(crate::profiles::unfollow(req).await) });
-        api.at("/tags")
-            .get(|req| async move { result_to_response(crate::articles::tags(req).await) });
-        api.at("/articles")
-            .get(|req| async move { result_to_response(crate::articles::list_articles(req).await) })
-            .post(
-                |req| async move { result_to_response(crate::articles::insert_article(req).await) },
-            );
-        api.at("/articles/feed")
-            .get(|req| async move { result_to_response(crate::articles::feed(req).await) });
-        api.at("/articles/:slug")
-            .get(|req| async move { result_to_response(crate::articles::get_article(req).await) })
-            .put(
-                |req| async move { result_to_response(crate::articles::update_article(req).await) },
-            )
-            .delete(
-                |req| async move { result_to_response(crate::articles::delete_article(req).await) },
-            );
-        api.at("/articles/:slug/comments")
-            .get(|req| async move { result_to_response(crate::comments::get(req).await) })
-            .post(|req| async move { result_to_response(crate::comments::create(req).await) });
-        api.at("/articles/:slug/comments/:id")
-            .delete(|req| async move { result_to_response(crate::comments::delete(req).await) });
-        api.at("/articles/:slug/favorite")
-            .post(|req| async move { result_to_response(crate::articles::favorite(req).await) })
-            .delete(
-                |req| async move { result_to_response(crate::articles::unfavorite(req).await) },
-            );
-    });
-    app
+pub fn add_routes<R: Repository + Send + Sync>(mut api: Server<Context<R>>) -> Server<Context<R>> {
+    api.at("/api/user")
+        .get(|req| async move { result_to_response(crate::users::get_current_user(req).await) })
+        .put(|req| async move { result_to_response(crate::users::update_user(req).await) });
+    api.at("/api/users")
+        .post(|req| async move { result_to_response(crate::users::register(req).await) });
+    api.at("/api/users/login")
+        .post(|req| async move { result_to_response(crate::users::login(req).await) });
+    api.at("/api/profiles/:username")
+        .get(|req| async move { result_to_response(crate::profiles::get_profile(req).await) });
+    api.at("/api/profiles/:username/follow")
+        .post(|req| async move { result_to_response(crate::profiles::follow(req).await) })
+        .delete(|req| async move { result_to_response(crate::profiles::unfollow(req).await) });
+    api.at("/api/tags")
+        .get(|req| async move { result_to_response(crate::articles::tags(req).await) });
+    api.at("/api/articles")
+        .get(|req| async move { result_to_response(crate::articles::list_articles(req).await) })
+        .post(|req| async move { result_to_response(crate::articles::insert_article(req).await) });
+    api.at("/api/articles/feed")
+        .get(|req| async move { result_to_response(crate::articles::feed(req).await) });
+    api.at("/api/articles/:slug")
+        .get(|req| async move { result_to_response(crate::articles::get_article(req).await) })
+        .put(|req| async move { result_to_response(crate::articles::update_article(req).await) })
+        .delete(
+            |req| async move { result_to_response(crate::articles::delete_article(req).await) },
+        );
+    api.at("/api/articles/:slug/comments")
+        .get(|req| async move { result_to_response(crate::comments::get(req).await) })
+        .post(|req| async move { result_to_response(crate::comments::create(req).await) });
+    api.at("/api/articles/:slug/comments/:id")
+        .delete(|req| async move { result_to_response(crate::comments::delete(req).await) });
+    api.at("/api/articles/:slug/favorite")
+        .post(|req| async move { result_to_response(crate::articles::favorite(req).await) })
+        .delete(|req| async move { result_to_response(crate::articles::unfavorite(req).await) });
+    api
 }
 
 pub fn add_middleware<State: 'static + Sync + Send>(mut app: Server<State>) -> Server<State> {

--- a/src/web/src/articles/insert.rs
+++ b/src/web/src/articles/insert.rs
@@ -26,7 +26,7 @@ impl From<NewArticleRequest> for domain::ArticleContent {
             title: a.title,
             description: a.description,
             body: a.body,
-            tag_list: a.tag_list.unwrap_or(vec![]),
+            tag_list: a.tag_list.unwrap_or_else(|| vec![]),
         }
     }
 }

--- a/src/web/src/articles/insert.rs
+++ b/src/web/src/articles/insert.rs
@@ -17,7 +17,7 @@ pub struct NewArticleRequest {
     pub title: String,
     pub description: String,
     pub body: String,
-    pub tag_list: Vec<String>,
+    pub tag_list: Option<Vec<String>>,
 }
 
 impl From<NewArticleRequest> for domain::ArticleContent {
@@ -26,7 +26,7 @@ impl From<NewArticleRequest> for domain::ArticleContent {
             title: a.title,
             description: a.description,
             body: a.body,
-            tag_list: a.tag_list,
+            tag_list: a.tag_list.unwrap_or(vec![]),
         }
     }
 }

--- a/src/web/src/articles/list.rs
+++ b/src/web/src/articles/list.rs
@@ -4,7 +4,7 @@ use crate::{Context, ErrorResponse};
 use domain::repositories::Repository;
 use serde::Deserialize;
 use std::str::FromStr;
-use tide::{Request, Response};
+use tide::{IntoResponse, Request, Response};
 use uuid::Uuid;
 
 #[derive(Default, Deserialize, Debug, Clone)]
@@ -34,13 +34,7 @@ impl FromStr for ArticleQuery {
 pub async fn list_articles<R: 'static + Repository + Sync + Send>(
     cx: Request<Context<R>>,
 ) -> Result<Response, ErrorResponse> {
-    // This can be avoided once https://github.com/http-rs/tide/pull/384 gets merged
-    let query = cx.query::<ArticleQuery>().unwrap_or(ArticleQuery {
-        author: None,
-        favorited: None,
-        tag: None,
-    });
-
+    let query = cx.query::<ArticleQuery>().map_err(|e| e.into_response())?;
     let repository = &cx.state().repository;
 
     let user_id: Option<Uuid> = cx.get_claims().map(|c| c.user_id()).ok();

--- a/src/web/tests/web_articles.rs
+++ b/src/web/tests/web_articles.rs
@@ -121,7 +121,7 @@ fn should_create_article() {
                 title: article.title.clone(),
                 description: article.description.clone(),
                 body: article.body.clone(),
-                tag_list: article.tag_list.clone(),
+                tag_list: Some(article.tag_list.clone()),
             },
         };
         server


### PR DESCRIPTION
A small change required in how we mount routes to the `app` struct and a workaround that we can now remove because the fix is included in the release :rocket: 